### PR TITLE
add additional file to little snitch configuration

### DIFF
--- a/mackup/applications/littlesnitch.cfg
+++ b/mackup/applications/littlesnitch.cfg
@@ -3,6 +3,7 @@ name = LittleSnitch
 
 [configuration_files]
 Library/Preferences/at.obdev.LittleSnitchNetworkMonitor.plist
+Library/Preferences/at.obdev.littlesnitch.networkmonitor.plist
 Library/Application Support/Little Snitch/rules.usr.xpl
 Library/Application Support/Little Snitch/configuration.xpl
 Library/Application Support/Little Snitch/configuration.user.xpl


### PR DESCRIPTION
Little Snitch seems to have changed the file name just slightly in the latest version. Added it on as an additional file to backup.

Based on a fresh intall of Little Snitch on my Mac.